### PR TITLE
[qgis-server] Use unstash instead of wget

### DIFF
--- a/api_webgisclient/Jenkinsfile
+++ b/api_webgisclient/Jenkinsfile
@@ -1,9 +1,6 @@
 library identifier: "jenkins-shared-libs@${JENKINS_SHARED_LIBS_BRANCH}", retriever: modernSCM(
     [$class: 'GitSCMSource',
      remote: 'https://github.com/sogis/jenkins-shared-libs.git'])
-credentials = [
-    usernamePassword(credentialsId: 'jenkinsApi'                          , usernameVariable: 'apiUser'                 , passwordVariable: 'PwdApiUser'),
-    ]
 properties([
      parameters([
          [$class: 'ChoiceParameter',

--- a/api_webgisclient/data-service/Jenkinsfile
+++ b/api_webgisclient/data-service/Jenkinsfile
@@ -70,8 +70,7 @@ pipeline {
                     credentials = [ 
                         usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-ogc-server-secret'          , usernameVariable: 'DbUserOgcServer'         , passwordVariable: 'PwdOgcServer'),
                         usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-secret'       , usernameVariable: 'DbUserSogisService'      , passwordVariable: 'PwdSogisService'),
-                        usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-write-secret' , usernameVariable: 'DbUserSogisServiceWrite' , passwordVariable: 'PwdSogisServiceWrite'),
-                        usernamePassword(credentialsId: 'jenkinsApi'                                        , usernameVariable: 'apiUser'                 , passwordVariable: 'PwdApiUser')
+                        usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-write-secret' , usernameVariable: 'DbUserSogisServiceWrite' , passwordVariable: 'PwdSogisServiceWrite')
                         ]
                     }
                 }

--- a/api_webgisclient/featureinfo-service/Jenkinsfile
+++ b/api_webgisclient/featureinfo-service/Jenkinsfile
@@ -86,8 +86,7 @@ pipeline {
                     credentials = [ 
                         usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-ogc-server-secret'          , usernameVariable: 'DbUserOgcServer'         , passwordVariable: 'PwdOgcServer'),
                         usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-secret'       , usernameVariable: 'DbUserSogisService'      , passwordVariable: 'PwdSogisService'),
-                        usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-write-secret' , usernameVariable: 'DbUserSogisServiceWrite' , passwordVariable: 'PwdSogisServiceWrite'),
-                        usernamePassword(credentialsId: 'jenkinsApi'                                        , usernameVariable: 'apiUser'                 , passwordVariable: 'PwdApiUser')
+                        usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-write-secret' , usernameVariable: 'DbUserSogisServiceWrite' , passwordVariable: 'PwdSogisServiceWrite')
                         ]
                     }
                 }

--- a/api_webgisclient/qgis-server/Jenkinsfile
+++ b/api_webgisclient/qgis-server/Jenkinsfile
@@ -72,8 +72,7 @@ pipeline {
                     jobName = JOB_NAME
                     credentials = [ 
                         usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-ogc-server-secret'   , usernameVariable: 'DbUserOgcServer'   , passwordVariable: 'PwdOgcServer'),
-                        usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-secret', usernameVariable: 'DbUserSogisService', passwordVariable: 'PwdSogisService'),
-                        usernamePassword(credentialsId: 'jenkinsApi'                                 , usernameVariable: 'apiUser'           , passwordVariable: 'PwdApiUser')
+                        usernamePassword(credentialsId: (env.NAMESPACE_JENKINS) + '-jenkins-dbuser-sogis-service-secret', usernameVariable: 'DbUserSogisService', passwordVariable: 'PwdSogisService')
                         ]
                     }
                 }
@@ -171,30 +170,28 @@ pipeline {
                   }
              }
             steps {
-                withCredentials ( credentials ) {
-                    container('json2qgs') {
-                        dir('qgs') {
-                          unstash name: configFileName
-                          unstash name: 'somap_wfs.json'
-                          unstash name: 'somap_print.json'
-                        }
-                        sh """
-                            if [ ! -d "config/default" ]; then
-                              mkdir -p config/default
-                            fi
-                            python3 /srv/json2qgs/json2qgs.py qgs/somap.json wms ./config/default 2 --qgsName somap --qgsTemplateDir /srv/json2qgs/qgs
-                            python3 /srv/json2qgs/json2qgs.py qgs/somap_print.json wms ./config/default 2 --qgsName somap_print --qgsTemplateDir /srv/json2qgs/qgs
-                            python3 /srv/json2qgs/json2qgs.py qgs/somap_wfs.json wfs ./config/default 2 --qgsName somap_wfs --qgsTemplateDir /srv/json2qgs/qgs
-                        """
-                        }
-                    script {
-                        PODNAME= sh([script: 'oc get pods -o custom-columns=POD:.metadata.name --no-headers -n ${namespace} | grep qgis-server | grep -v -E -m 1 "featureinfo|build|print|deploy"', returnStdout: true]).trim()
-                        sh """
-                           oc rsync -n ${namespace} config/default/ $PODNAME:/data
-                        """
-                        }
-                    archiveArtifacts artifacts: 'config/**', onlyIfSuccessful: true, allowEmptyArchive: true
+                container('json2qgs') {
+                    dir('qgs') {
+                      unstash name: configFileName
+                      unstash name: 'somap_wfs.json'
+                      unstash name: 'somap_print.json'
                     }
+                    sh """
+                        if [ ! -d "config/default" ]; then
+                          mkdir -p config/default
+                        fi
+                        python3 /srv/json2qgs/json2qgs.py qgs/somap.json wms ./config/default 2 --qgsName somap --qgsTemplateDir /srv/json2qgs/qgs
+                        python3 /srv/json2qgs/json2qgs.py qgs/somap_print.json wms ./config/default 2 --qgsName somap_print --qgsTemplateDir /srv/json2qgs/qgs
+                        python3 /srv/json2qgs/json2qgs.py qgs/somap_wfs.json wfs ./config/default 2 --qgsName somap_wfs --qgsTemplateDir /srv/json2qgs/qgs
+                    """
+                    }
+                script {
+                    PODNAME= sh([script: 'oc get pods -o custom-columns=POD:.metadata.name --no-headers -n ${namespace} | grep qgis-server | grep -v -E -m 1 "featureinfo|build|print|deploy"', returnStdout: true]).trim()
+                    sh """
+                        oc rsync -n ${namespace} config/default/ $PODNAME:/data
+                    """
+                    }
+                archiveArtifacts artifacts: 'config/**', onlyIfSuccessful: true, allowEmptyArchive: true
                 }
             post {
                 always {

--- a/api_webgisclient/qgis-server/Jenkinsfile
+++ b/api_webgisclient/qgis-server/Jenkinsfile
@@ -173,11 +173,15 @@ pipeline {
             steps {
                 withCredentials ( credentials ) {
                     container('json2qgs') {
+                        dir('qgs') {
+                          unstash name: configFileName
+                          unstash name: 'somap_wfs.json'
+                          unstash name: 'somap_print.json'
+                        }
                         sh """
                             if [ ! -d "config/default" ]; then
                               mkdir -p config/default
                             fi
-                            wget -r -np -nd -erobots=off -A '*.json' --reject-regex '/\\*.+\\*/|auto_refresh' --no-check-certificate --auth-no-challenge --user='$apiUser' --password='$PwdApiUser'  '$JOB_URL$buildNumber/artifact/config/default/' -P qgs
                             python3 /srv/json2qgs/json2qgs.py qgs/somap.json wms ./config/default 2 --qgsName somap --qgsTemplateDir /srv/json2qgs/qgs
                             python3 /srv/json2qgs/json2qgs.py qgs/somap_print.json wms ./config/default 2 --qgsName somap_print --qgsTemplateDir /srv/json2qgs/qgs
                             python3 /srv/json2qgs/json2qgs.py qgs/somap_wfs.json wfs ./config/default 2 --qgsName somap_wfs --qgsTemplateDir /srv/json2qgs/qgs


### PR DESCRIPTION
Use unstash instead of wget for obtaining three JSON config files from the controller. And remove the jenkinsApi credentials in various places.

This works only after https://github.com/sogis/jenkins-shared-libs/pull/8 is merged.

After completion, the jenkinsApi credentials can be removed from Jenkins.